### PR TITLE
Changes to options for therminal functions libaries

### DIFF
--- a/OpenFOAM-dev/multiRegionReactingFoam/fluid/readFluidMultiRegionPIMPLEControls.H
+++ b/OpenFOAM-dev/multiRegionReactingFoam/fluid/readFluidMultiRegionPIMPLEControls.H
@@ -16,6 +16,6 @@
         pimple.lookupOrDefault("consistent", false);
         
 //    pressureControl pressureControl(p, rho, pimple.dict(), false);
-    pressureControl pressureControl(p, rho, mesh.solutionDict().subDict("PIMPLE"), false);
+        Foam::pressureControl pressureControl(p, rho, mesh.solutionDict().subDict("PIMPLE"), false);
  
 

--- a/OpenFOAM-dev/multiRegionReactingFoam/multiRegionReactingFoam.C
+++ b/OpenFOAM-dev/multiRegionReactingFoam/multiRegionReactingFoam.C
@@ -52,6 +52,7 @@ Description
 #include "multivariateScheme.H"
 #include "fvcSmooth.H"
 #include "localEulerDdtScheme.H"
+#include "pressureControl.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 

--- a/OpenFOAM-dev/multiRegionReactingFoam/multiRegionSimpleReactingFoam/Make/options
+++ b/OpenFOAM-dev/multiRegionReactingFoam/multiRegionSimpleReactingFoam/Make/options
@@ -36,7 +36,7 @@ EXE_LIBS = \
     -lradiationModels \
     -lfvOptions \
     -lregionModels \
-    -lthermophysicalFunctions \
+    -lthermophysicalProperties \
     -lreactionThermophysicalModels \
     -lsampling
 


### PR DESCRIPTION
When trying to build multiRegionReactingFoam for Open-dev I encountered a number of syntax errors. This might be related to the way it was built, I am not sure. Open-dev was built from source and multiRegionReactingFoam/Open-dev was added into the build chain. These are the fixes I applied to get  multiRegionReactingFoam building with the latest Open-dev changes. 

I have run the binary finds and they seem to work but I don't have any config files for a full run. Could this please be tested by someone with experience running the solver? 
